### PR TITLE
change tool pose conversion

### DIFF
--- a/ros_interface/robots/jaco.py
+++ b/ros_interface/robots/jaco.py
@@ -390,8 +390,9 @@ class JacoInterface(JacoRobot):
             elif cmd.type == 'TOOL':
                 # command end effector pose in cartesian space
                 current_tool_pose = self.get_tool_pose()
-                position, orientation_q, orientation_rad, orientation_deg = convert_tool_pose(current_tool_pose, cmd.unit, cmd.relative, cmd.data[:3], cmd.data[3:])
-                msg, success = self.send_tool_pose_cmd(position, orientation_q)
+                pose_mq, orientation_q, orientation_rad = convert_tool_pose(current_tool_pose, cmd.unit, cmd.relative, cmd.data[:3], cmd.data[3:])
+                poses = [float(n) for n in pose_mq]
+                msg, success = self.send_tool_pose_cmd(poses[:3], poses[3:])
                 return self.get_state(success=success, msg=msg)
  
             else:
@@ -414,4 +415,3 @@ class JacoInterface(JacoRobot):
 
 if __name__ == '__main__':
     jaco = JacoInterface()
-

--- a/ros_interface/robots/utils.py
+++ b/ros_interface/robots/utils.py
@@ -222,18 +222,18 @@ def convert_joint_angles(current_joint_angle_radians, unit, relative, target_joi
     target_joint_position: relative or absolute joint position in degrees or radians. TODO size of input
     """
  
-    assert unit in ['deg', 'rad']
+    assert unit in ['mdeg', 'mrad']
     # current joint estimate is in degrees
     if relative:
         current_joint_angle_degrees = [np.rad2deg(current_joint_angle_radians[i]) for i in range(len(current_joint_angle_radians))]
-    if unit == 'deg':
+    if unit == 'mdeg':
         # get absolute value
         if relative:
             target_joint_degree = [target_joint_position[i] + current_joint_angle_degrees[i] for i in range(len(target_joint_position))]
         else:
             target_joint_degree = target_joint_position
         target_joint_radian = list(map(math.radians, target_joint_degree))
-    elif unit == 'rad':
+    elif unit == 'mrad':
         if relative:
             # get absolute value
             target_joint_degree = [math.degrees(target_joint_position[i]) + current_joint_angle_degrees[i] for i in range(len(target_joint_position))]

--- a/ros_interface/robots/utils.py
+++ b/ros_interface/robots/utils.py
@@ -160,8 +160,6 @@ def convert_tool_pose(current_tool_pose, unit, relative, position, orientation):
 
     return pose_mq_, pose_mdeg_, pose_mrad_
 
-
-
 def convert_tool_pose_old_version(current_tool_pose, unit, relative, position, orientation):
     """
     Mel: This was the older version of code, the outputs of this implementation and above are


### PR DESCRIPTION
Updated the convert_tool_pose API according to the implementation from `https://github.com/Kinovarobotics/kinova-ros/blob/master/kinova_demo/nodes/kinova_demo/pose_action_client.py`
The two conversions don't produce the same end results. So keeping both implementation for now, might want to compare this with the sim version from robosuite.